### PR TITLE
Fix terminology concerning metric prefixes

### DIFF
--- a/doc/avtools-common-opts.texi
+++ b/doc/avtools-common-opts.texi
@@ -1,10 +1,11 @@
 All the numerical options, if not specified otherwise, accept in input
 a string representing a number, which may contain one of the
-International System number postfixes, for example 'K', 'M', 'G'.
-If 'i' is appended after the postfix, powers of 2 are used instead of
-powers of 10. The 'B' postfix multiplies the value for 8, and can be
-appended after another postfix or used alone. This allows using for
-example 'KB', 'MiB', 'G' and 'B' as postfix.
+SI unit prefixes, for example 'K', 'M', 'G'.
+If 'i' is appended after the prefix, binary prefixes are used,
+which are based on powers of 1024 instead of powers of 1000.
+The 'B' postfix multiplies the value by 8, and can be
+appended after a unit prefix or used alone. This allows using for
+example 'KB', 'MiB', 'G' and 'B' as number postfix.
 
 Options which do not take arguments are boolean options, and set the
 corresponding value to true. They can be set to false by prefixing


### PR DESCRIPTION
'k', 'M', and 'G' are **SI (unit) prefixes** or **metric prefixes**,
not 'number postfixes'. Also, the statement regarding binary
prefixes ("powers of 2 are used instead of powers of 10")
might be misinterpreted (1 kB = 10^3 B, but 1 KiB != 2^3 B).

Update: This has in the meantime been submitted and merged via libav-devel mailing list.
