### PR TITLE
configure: fix compilation with freetype 2.5.1

### DIFF
--- a/configure
+++ b/configure
@@ -3844,7 +3844,9 @@ enabled frei0r            && { check_header frei0r.h || die "ERROR: frei0r.h hea
 enabled gnutls            && require_pkg_config gnutls gnutls/gnutls.h gnutls_global_init
 enabled libfaac           && require2 libfaac "stdint.h faac.h" faacEncGetVersion -lfaac
 enabled libfdk_aac        && require libfdk_aac fdk-aac/aacenc_lib.h aacEncOpen -lfdk-aac
-enabled libfreetype       && require_pkg_config freetype2 "ft2build.h freetype/freetype.h" FT_Init_FreeType
+enabled libfreetype       && {
+			{ check_pkg_config freetype2 "ft2build.h freetype/freetype.h" FT_Init_FreeType && require_pkg_config freetype2 "ft2build.h freetype/freetype.h" FT_Init_FreeType;   }
+			{ check_pkg_config freetype2 "ft2build.h freetype2/freetype.h" FT_Init_FreeType && require_pkg_config freetype2 "ft2build.h freetype2/freetype.h" FT_Init_FreeType; } }
 enabled libgsm            && { for gsm_hdr in "gsm.h" "gsm/gsm.h"; do
                                    check_lib "${gsm_hdr}" gsm_create -lgsm && break;
                                done || die "ERROR: libgsm not found"; }

--- a/libavfilter/vf_drawtext.c
+++ b/libavfilter/vf_drawtext.c
@@ -47,7 +47,6 @@
 #include "video.h"
 
 #include <ft2build.h>
-#include <freetype/config/ftheader.h>
 #include FT_FREETYPE_H
 #include FT_GLYPH_H
 


### PR DESCRIPTION
Tested with freetype 2.4.11 and 2.5.1.

Include seems unnecessary.
