### PR TITLE
compilation fix: add missing includes

### DIFF
--- a/ffserver.c
+++ b/ffserver.c
@@ -29,6 +29,7 @@
 #include <strings.h>
 #include <stdlib.h>
 #include "libavformat/avformat.h"
+#include "libavformat/internal.h"
 #include "libavformat/network.h"
 #include "libavformat/os_support.h"
 #include "libavformat/rtpdec.h"

--- a/libavcodec/vaapi_mpeg4.c
+++ b/libavcodec/vaapi_mpeg4.c
@@ -22,6 +22,8 @@
 
 #include "vaapi_internal.h"
 
+#include "h263.h"
+
 /** Reconstruct bitstream intra_dc_vlc_thr */
 static int mpeg4_get_intra_dc_vlc_thr(MpegEncContext *s)
 {


### PR DESCRIPTION
I'm compiling an old project using libav 0.6 on a recent ubuntu. I got some minor include errors when building libav 0.6.

gcc (Ubuntu 4.8.2-19ubuntu1) 4.8.2
