### PR TITLE
convert UTF-8 log back to UTF-16 before print it to windows cmd console

### DIFF
--- a/libavutil/log.c
+++ b/libavutil/log.c
@@ -26,6 +26,10 @@
 
 #include "config.h"
 
+#if HAVE_COMMANDLINETOARGVW && defined(_WIN32)
+#include <malloc.h>
+#endif
+
 #if HAVE_UNISTD_H
 #include <unistd.h>
 #endif
@@ -100,7 +104,37 @@ static void colored_fputs(int level, int tint, const char *str)
     default:
         break;
     }
+#if HAVE_COMMANDLINETOARGVW && defined(_WIN32)
+    int wcBufLen = 0;
+    wcBufLen = MultiByteToWideChar(CP_UTF8, 0, str, -1, NULL, 0);
+    if (wcBufLen == 0) {
+        fputs("Failed to convert multibyte log string to widechar.\n", stderr);
+        exit(1);
+    }
+    __try {
+        // stack buffer is faster.
+        // wchar_t wcBuf[wcBufLen];
+        // VLA is still not supported in VS2013('cause C11 makes it optional).
+        // use alloca instead.
+        wchar_t* wcBuf = (wchar_t*)_malloca(wcBufLen * sizeof(wchar_t));
+        wcBufLen = MultiByteToWideChar(CP_UTF8, 0, str, -1, wcBuf, wcBufLen);
+        WriteConsoleW(GetStdHandle(STD_ERROR_HANDLE), wcBuf, wcBufLen, &wcBufLen, NULL);
+        _freea(wcBuf);
+    }
+    __except( GetExceptionCode() == STATUS_STACK_OVERFLOW ) {
+        // windows SEH exception caught
+        if(_resetstkoflw()) {
+            fputs("Stack overflow in log.c, and the reset on the stack failed", stderr);
+            exit(1);
+        }
+        wchar_t* wcBuf = (wchar_t*)malloc(wcBufLen * sizeof(wchar_t));
+        wcBufLen = MultiByteToWideChar(CP_UTF8, 0, str, -1, wcBuf, wcBufLen);
+        WriteConsoleW(GetStdHandle(STD_ERROR_HANDLE), wcBuf, wcBufLen, &wcBufLen, NULL);
+        free(wcBuf);
+    }
+#else
     fputs(str, stderr);
+#endif
     if (use_color) {
         reset_color();
     }


### PR DESCRIPTION
The log facility in libav will convert command line parameters to UTF-8 before processing them, but when printing those converted UTF-8 log to windows cmd.exe console, some charactors(such as chinese charactors in file names) will get displayed as garbage charactors because of the mismatch of ANSI encoding in the user's windows environment and UTF-8. This patch will convert them back to windows Unicode strings before output.
