### PR TITLE
movenc.c: Write total number of tracks as part of metadata.

### DIFF
--- a/libavformat/movenc.c
+++ b/libavformat/movenc.c
@@ -2038,6 +2038,10 @@ static int mov_write_trkn_tag(AVIOContext *pb, MOVMuxContext *mov,
     AVDictionaryEntry *t = av_dict_get(s->metadata, "track", NULL, 0);
     int size = 0, track = t ? atoi(t->value) : 0;
     if (track) {
+        int tracks = 0;
+        char *slash = strchr(t->value, '/');
+        if (slash)
+            tracks = atoi(slash + 1);
         avio_wb32(pb, 32); /* size */
         ffio_wfourcc(pb, "trkn");
         avio_wb32(pb, 24); /* size */
@@ -2046,7 +2050,7 @@ static int mov_write_trkn_tag(AVIOContext *pb, MOVMuxContext *mov,
         avio_wb32(pb, 0);
         avio_wb16(pb, 0);        // empty
         avio_wb16(pb, track);    // track number
-        avio_wb16(pb, 0);        // total track number
+        avio_wb16(pb, tracks);   // total track number
         avio_wb16(pb, 0);        // empty
         size = 32;
     }


### PR DESCRIPTION
Fix for setting total tracks number in metadata
Same issue was fixed in ffmpeg:
https://github.com/macoscope/ffmpeg/commit/bb7f71d9b6aedf8e83061e326f09843fd21fcbce
