### PR TITLE
[libavcodec] Fix missing control flow scopes or misleading indentation

### DIFF
--- a/libavcodec/ivi_dsp.c
+++ b/libavcodec/ivi_dsp.c
@@ -539,11 +539,12 @@ void ff_ivi_inverse_slant_8x8(const int32_t *in, int16_t *out, uint32_t pitch, c
             IVI_INV_SLANT8(src[0], src[8], src[16], src[24], src[32], src[40], src[48], src[56],
                            dst[0], dst[8], dst[16], dst[24], dst[32], dst[40], dst[48], dst[56],
                            t0, t1, t2, t3, t4, t5, t6, t7, t8);
-        } else
+        } else {
             dst[0] = dst[8] = dst[16] = dst[24] = dst[32] = dst[40] = dst[48] = dst[56] = 0;
+        }
 
-            src++;
-            dst++;
+        src++;
+        dst++;
     }
 #undef COMPENSATE
 
@@ -579,11 +580,11 @@ void ff_ivi_inverse_slant_4x4(const int32_t *in, int16_t *out, uint32_t pitch, c
             IVI_INV_SLANT4(src[0], src[4], src[8], src[12],
                            dst[0], dst[4], dst[8], dst[12],
                            t0, t1, t2, t3, t4);
-        } else
+        } else {
             dst[0] = dst[4] = dst[8] = dst[12] = 0;
-
-            src++;
-            dst++;
+        }
+        src++;
+        dst++;
     }
 #undef COMPENSATE
 

--- a/libavcodec/mpegvideo.c
+++ b/libavcodec/mpegvideo.c
@@ -544,11 +544,12 @@ do {\
 
     if (s1->bitstream_buffer) {
         if (s1->bitstream_buffer_size +
-            AV_INPUT_BUFFER_PADDING_SIZE > s->allocated_bitstream_buffer_size)
+            AV_INPUT_BUFFER_PADDING_SIZE > s->allocated_bitstream_buffer_size) {
             av_fast_malloc(&s->bitstream_buffer,
                            &s->allocated_bitstream_buffer_size,
                            s1->allocated_bitstream_buffer_size);
             s->bitstream_buffer_size = s1->bitstream_buffer_size;
+        }
         memcpy(s->bitstream_buffer, s1->bitstream_buffer,
                s1->bitstream_buffer_size);
         memset(s->bitstream_buffer + s->bitstream_buffer_size, 0,
@@ -850,10 +851,10 @@ av_cold int ff_mpv_common_init(MpegEncContext *s)
             for (i = 0; i < nb_slices; i++) {
                 if (init_duplicate_context(s->thread_context[i]) < 0)
                     goto fail;
-                    s->thread_context[i]->start_mb_y =
-                        (s->mb_height * (i) + nb_slices / 2) / nb_slices;
-                    s->thread_context[i]->end_mb_y   =
-                        (s->mb_height * (i + 1) + nb_slices / 2) / nb_slices;
+                s->thread_context[i]->start_mb_y =
+                    (s->mb_height * (i) + nb_slices / 2) / nb_slices;
+                s->thread_context[i]->end_mb_y   =
+                    (s->mb_height * (i + 1) + nb_slices / 2) / nb_slices;
             }
         } else {
             if (init_duplicate_context(s) < 0)
@@ -974,10 +975,10 @@ int ff_mpv_common_frame_size_change(MpegEncContext *s)
             for (i = 0; i < nb_slices; i++) {
                 if ((err = init_duplicate_context(s->thread_context[i])) < 0)
                     goto fail;
-                    s->thread_context[i]->start_mb_y =
-                        (s->mb_height * (i) + nb_slices / 2) / nb_slices;
-                    s->thread_context[i]->end_mb_y   =
-                        (s->mb_height * (i + 1) + nb_slices / 2) / nb_slices;
+                s->thread_context[i]->start_mb_y =
+                    (s->mb_height * (i) + nb_slices / 2) / nb_slices;
+                s->thread_context[i]->end_mb_y   =
+                    (s->mb_height * (i + 1) + nb_slices / 2) / nb_slices;
             }
         } else {
             if (init_duplicate_context(s) < 0)

--- a/libavcodec/qdm2.c
+++ b/libavcodec/qdm2.c
@@ -693,7 +693,7 @@ static void fill_coding_method_array(sb_int8_array tone_level_idx,
     if (!superblocktype_2_3) {
         /* This case is untested, no samples available */
         SAMPLES_NEEDED
-        for (ch = 0; ch < nb_channels; ch++)
+        for (ch = 0; ch < nb_channels; ch++) {
             for (sb = 0; sb < 30; sb++) {
                 for (j = 1; j < 63; j++) {  // The loop only iterates to 63 so the code doesn't overflow the buffer
                     add1 = tone_level_idx[ch][sb][j] - 10;
@@ -783,6 +783,7 @@ static void fill_coding_method_array(sb_int8_array tone_level_idx,
                                     coding_method[ch][sb][j] = 30;
                             }
                         }
+        }
     } else { // superblocktype_2_3 != 0
         for (ch = 0; ch < nb_channels; ch++)
             for (sb = 0; sb < 30; sb++)


### PR DESCRIPTION
I'm not 100% sure if the resolution is correct, but the indentation in the original code suggests that something else what intended. I'd welcome advice on the intended behaviour, and I will change the commit accordingly.
