### PR TITLE
dxva2.c: ff_dxva2_get_surface_index asserts when using AV_PIX_FMT_DXVA2_VLD

### DIFF
--- a/libavcodec/dxva2.c
+++ b/libavcodec/dxva2.c
@@ -42,6 +42,7 @@ unsigned ff_dxva2_get_surface_index(const AVCodecContext *avctx,
     unsigned i;
 
     for (i = 0; i < DXVA_CONTEXT_COUNT(avctx, ctx); i++)
+    {
 #if CONFIG_D3D11VA
         if (avctx->pix_fmt == AV_PIX_FMT_D3D11VA_VLD && ctx->d3d11va.surface[i] == surface) {
             D3D11_VIDEO_DECODER_OUTPUT_VIEW_DESC viewDesc;
@@ -53,7 +54,8 @@ unsigned ff_dxva2_get_surface_index(const AVCodecContext *avctx,
         if (avctx->pix_fmt == AV_PIX_FMT_DXVA2_VLD && ctx->dxva2.surface[i] == surface)
             return i;
 #endif
-
+    }
+    
     assert(0);
     return 0;
 }


### PR DESCRIPTION
ff_dxva2_get_surface_index asserts when using AV_PIX_FMT_DXVA2_VLD format. Braces around for loop must be added for correct surface index lookup.
