### PR TITLE
Fixed segfault when decoding subtitles

### DIFF
--- a/libavcodec/dvbsubdec.c
+++ b/libavcodec/dvbsubdec.c
@@ -1281,13 +1281,17 @@ static int dvbsub_display_end_segment(AVCodecContext *avctx, const uint8_t *buf,
     }
 
     sub->num_rects = ctx->display_list_size;
-    if (sub->num_rects <= 0)
-        return AVERROR_INVALIDDATA;
 
-    sub->rects = av_mallocz_array(sub->num_rects * sub->num_rects,
-                                  sizeof(*sub->rects));
-    if (!sub->rects)
-        return AVERROR(ENOMEM);
+    if (sub->num_rects > 0){
+        sub->rects = av_mallocz(sizeof(*sub->rects) * sub->num_rects);
+        if (!sub->rects)
+            return AVERROR(ENOMEM);
+        for (i=0; i<sub->num_rects; i++) {
+            sub->rects[i] = av_mallocz(sizeof(*sub->rects[i]));
+            if (!sub->rects[i])
+                return AVERROR(ENOMEM);
+        }
+    }
 
     i = 0;
 


### PR DESCRIPTION
This fixes a segfault (originally found in Movian, but traced to libav) when decoding subtitles because only an array of rects is allocated, but not the actual structs it contains. The issue was probably introduced in commit 2383323661f3b8342b2c4d356fcfe8c5d1b045f8 where the loop to allocate the rects in the array was thrown away.
