### PR TITLE
Add ABGR map only if VA_FOURCC_ABGR is defined

### DIFF
--- a/libavutil/hwcontext_vaapi.c
+++ b/libavutil/hwcontext_vaapi.c
@@ -107,8 +107,10 @@ static const struct {
   //MAP(BGRX, RGB32,   BGR0),
     MAP(RGBA, RGB32,   RGBA),
   //MAP(RGBX, RGB32,   RGB0),
+#ifdef VA_FOURCC_ABGR
     MAP(ABGR, RGB32,   ABGR),
   //MAP(XBGR, RGB32,   0BGR),
+#endif
     MAP(ARGB, RGB32,   ARGB),
   //MAP(XRGB, RGB32,   0RGB),
 };


### PR DESCRIPTION
I could not build libav with vaapi enabled, because my version of libva has no ABGR defined. So I added check for VA_FOURCC_ABGR to check if mapping to ABGR is possible.